### PR TITLE
Added 'write_mode' option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,12 +24,7 @@ inputs:
   write_mode:
     description: "Write mode is one of 'add', 'overwrite', or 'update' as defined in https://www.dropbox.com/developers/documentation/http/documentation#files-upload_session-finish
     required: false
-    type: choice
     default: 'add'
-    options:
-      - 'add'
-      - 'overwrite'
-      - 'update'
 
 branding:
   icon: "package"

--- a/action.yml
+++ b/action.yml
@@ -22,9 +22,14 @@ inputs:
     description: "Destination path in Dropbox."
     required: true
   write_mode:
-    description: "Write mode is one of 'add', 'overwrite', or 'update' as defined in https://www.dropbox.com/developers/documentation/http/documentation#files-upload_session-finish
+    description: "Write mode is one of 'add', 'overwrite', or 'update' as defined in https://www.dropbox.com/developers/documentation/http/documentation#files-upload_session-finish"
     required: false
+    type: choice
     default: 'add'
+    options:
+      - 'add'
+      - 'overwrite'
+      - 'update'
 
 branding:
   icon: "package"

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,15 @@ inputs:
   dropbox_path:
     description: "Destination path in Dropbox."
     required: true
+  write_mode:
+    description: "Write mode is one of 'add', 'overwrite', or 'update' as defined in https://www.dropbox.com/developers/documentation/http/documentation#files-upload_session-finish
+    required: false
+    type: choice
+    default: 'add'
+    options:
+      - 'add'
+      - 'overwrite'
+      - 'update'
 
 branding:
   icon: "package"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,7 +55,7 @@ cd ${chunkDir}
 
 # Upload chunks to Dropbox
 offset=0
-for file in `ls -l *`
+for file in *
 do
   echo "$file"
   fileSize=$(stat -c%s "$file")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,10 +20,10 @@ if [[ -z "$INPUT_APP_KEY" || -z "$INPUT_APP_SECRET" || -z "$INPUT_REFRESH_TOKEN"
   exit 1
 fi
 
-if [[ -z "$INPUT_MODE" ]]; then
+if [[ -z "$INPUT_WRITE_MODE" ]]; then
   input_mode = 'add'
 else
-  input_mode = "$INPUT_MODE"
+  input_mode = "$INPUT_WRITE_MODE"
 fi
 
 # Obtain the access token

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,6 +57,7 @@ cd ${chunkDir}
 offset=0
 for file in `ls -l *`
 do
+  echo "$file"
   fileSize=$(stat -c%s "$file")
   
   response=$(curl -s -X POST https://content.dropboxapi.com/2/files/upload_session/append_v2 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,7 +57,6 @@ cd ${chunkDir}
 offset=0
 for file in *
 do
-  echo "$file"
   fileSize=$(stat -c%s "$file")
   
   response=$(curl -s -X POST https://content.dropboxapi.com/2/files/upload_session/append_v2 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,12 @@ if [[ -z "$INPUT_APP_KEY" || -z "$INPUT_APP_SECRET" || -z "$INPUT_REFRESH_TOKEN"
   exit 1
 fi
 
+if [[ -z "$INPUT_MODE" ]]; then
+  input_mode = 'add'
+else
+  input_mode = "$INPUT_MODE"
+fi
+
 # Obtain the access token
 get_access_token
 
@@ -63,7 +69,7 @@ done
 # Finalize the upload session
 curl -s -X POST https://content.dropboxapi.com/2/files/upload_session/finish \
   --header "Authorization: Bearer ${apiToken}" \
-  --header "Dropbox-API-Arg: {\"cursor\": {\"session_id\": \"${sessionId}\",\"offset\": ${offset}},\"commit\": {\"path\": \"${INPUT_DROPBOX_PATH}\",\"mode\": \"add\",\"autorename\": true,\"mute\": false,\"strict_conflict\": false}}" \
+  --header "Dropbox-API-Arg: {\"cursor\": {\"session_id\": \"${sessionId}\",\"offset\": ${offset}},\"commit\": {\"path\": \"${INPUT_DROPBOX_PATH}\",\"mode\": \"$input_mode\",\"autorename\": true,\"mute\": false,\"strict_conflict\": false}}" \
   --header "Content-Type: application/octet-stream"
 
 # Clean up the chunk directory

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,10 +21,12 @@ if [[ -z "$INPUT_APP_KEY" || -z "$INPUT_APP_SECRET" || -z "$INPUT_REFRESH_TOKEN"
 fi
 
 if [[ -z "$INPUT_WRITE_MODE" ]]; then
-  input_mode = 'add'
+  input_mode='add'
 else
-  input_mode = "$INPUT_WRITE_MODE"
+  input_mode="$INPUT_WRITE_MODE"
 fi
+
+echo "Mode is: $input_mode"
 
 # Obtain the access token
 get_access_token

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,7 +69,7 @@ done
 # Finalize the upload session
 curl -s -X POST https://content.dropboxapi.com/2/files/upload_session/finish \
   --header "Authorization: Bearer ${apiToken}" \
-  --header "Dropbox-API-Arg: {\"cursor\": {\"session_id\": \"${sessionId}\",\"offset\": ${offset}},\"commit\": {\"path\": \"${INPUT_DROPBOX_PATH}\",\"mode\": \"$input_mode\",\"autorename\": true,\"mute\": false,\"strict_conflict\": false}}" \
+  --header "Dropbox-API-Arg: {\"cursor\": {\"session_id\": \"${sessionId}\",\"offset\": ${offset}},\"commit\": {\"path\": \"${INPUT_DROPBOX_PATH}\",\"mode\": \"${input_mode}\",\"autorename\": true,\"mute\": false,\"strict_conflict\": false}}" \
   --header "Content-Type: application/octet-stream"
 
 # Clean up the chunk directory


### PR DESCRIPTION
I added 'write_mode' as a parameter. In my specific use-case I needed to overwrite the existing files rather than just add new ones. This choice now allows for overwriting but defaults to the previous behavior.